### PR TITLE
Improve start flow UX

### DIFF
--- a/chess_trainer/templates/index.html
+++ b/chess_trainer/templates/index.html
@@ -112,12 +112,21 @@
     button:hover {
       background: var(--accent-hover);
     }
+    .message {
+      text-align: center;
+      font-weight: bold;
+      margin-bottom: var(--gap);
+      color: var(--accent);
+    }
   </style>
 </head>
 <body>
   <div class="container">
     <h1>Chess Training Bot Setup</h1>
-    <form action="/start" method="post">
+    {% if message %}
+    <p class="message">{{ message }}</p>
+    {% endif %}
+    <form action="/" method="post">
       <div class="openings-grid">
         <div class="section">
           <h2>White openings</h2>

--- a/chess_trainer/trainer.py
+++ b/chess_trainer/trainer.py
@@ -2,6 +2,8 @@
 import os
 import sys
 import shutil
+import threading
+from typing import Optional
 
 from berserk.exceptions import ResponseError
 
@@ -67,8 +69,14 @@ else:  # pragma: no cover - allows running tests without optional deps
 
 ############################################### Core Bot Logic ####################################
 
-def handle_events(bot_profile: BotProfile = BotProfile(), on_game_start=None):
+def handle_events(
+    bot_profile: BotProfile = BotProfile(),
+    on_game_start=None,
+    stop_event: Optional[threading.Event] = None,
+):
     for event in client.bots.stream_incoming_events():
+        if stop_event is not None and stop_event.is_set():
+            break
         t = event["type"]
         if t == "challenge":
             try:

--- a/chess_trainer/ui.py
+++ b/chess_trainer/ui.py
@@ -72,7 +72,8 @@ def index() -> str:
             STOP_EVENT = threading.Event()
 
             def on_game_start(game_id: str) -> None:
-                webbrowser.open(f"https://lichess.org/{game_id}")
+                # webbrowser.open(f"https://lichess.org/{game_id}")
+                pass # we already open the challenge above when we get the url back, so no need to open twice
 
             EVENT_THREAD = threading.Thread(
                 target=handle_events,

--- a/chess_trainer/ui.py
+++ b/chess_trainer/ui.py
@@ -16,6 +16,8 @@ from .bot_profile import BotProfile, white_openings, black_openings
 
 app = Flask(__name__)
 PROFILE = BotProfile()
+EVENT_THREAD: Optional[threading.Thread] = None
+STOP_EVENT: Optional[threading.Event] = None
 
 def build_options(name_list: List[str], field: str) -> str:
     out = []
@@ -45,34 +47,46 @@ def create_challenge(username: str) -> Optional[str]:
     return json_data.get("url", {})
 
 
-@app.get("/")
+@app.route("/", methods=["GET", "POST"])
 def index() -> str:
+    message: Optional[str] = None
+    if request.method == "POST":
+        global EVENT_THREAD, STOP_EVENT
+        PROFILE.chosen_white = request.form.getlist("white")
+        PROFILE.chosen_black = request.form.getlist("black")
+        PROFILE.challenge = int(request.form.get("challenge", "0") or 0)
+        username = request.form.get("username", "")
+
+        print(PROFILE)
+        url = create_challenge(username)
+        if not url:
+            message = "Failed to create challenge"
+        else:
+            webbrowser.open(url)
+
+            if EVENT_THREAD is not None and EVENT_THREAD.is_alive():
+                if STOP_EVENT is not None:
+                    STOP_EVENT.set()
+                EVENT_THREAD.join(timeout=0.1)
+
+            STOP_EVENT = threading.Event()
+
+            def on_game_start(game_id: str) -> None:
+                webbrowser.open(f"https://lichess.org/{game_id}")
+
+            EVENT_THREAD = threading.Thread(
+                target=handle_events,
+                args=(PROFILE, on_game_start, STOP_EVENT),
+                daemon=True,
+            )
+            EVENT_THREAD.start()
+            message = "Challenge created. Please accept it in the opened tab."
+
     white = build_options(white_openings, "white")
     black = build_options(black_openings, "black")
-    return render_template("index.html", white_options=white, black_options=black)
-
-@app.post("/start")
-def start() -> str:
-    PROFILE.chosen_white = request.form.getlist("white")
-    PROFILE.chosen_black = request.form.getlist("black")
-    PROFILE.challenge = int(request.form.get("challenge", "0") or 0)
-    username = request.form.get("username", "")
-
-    print(PROFILE)
-    url = create_challenge(username)
-    if not url:
-        return "Failed to create challenge"
-
-    webbrowser.open(url)
-
-    def on_game_start(game_id: str) -> None:
-        webbrowser.open(f"https://lichess.org/{game_id}")
-
-    thread = threading.Thread(
-        target=handle_events, args=(PROFILE, on_game_start), daemon=True
+    return render_template(
+        "index.html", white_options=white, black_options=black, message=message
     )
-    thread.start()
-    return "Challenge created. Please accept it in the opened tab."
 
 def run_server() -> None:
     """Start the frontend server and launch the default browser."""


### PR DESCRIPTION
## Summary
- keep all UI interactions on the index page
- show a status message after submitting the form
- allow restarting the bot thread when starting a new game

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867a1904c3c83219b313ac3081e7982