### PR TITLE
Refactor opening selection UI

### DIFF
--- a/chess_trainer/static/ui/src/OpeningsTree.jsx
+++ b/chess_trainer/static/ui/src/OpeningsTree.jsx
@@ -1,7 +1,7 @@
 // chess_trainer/static/ui/src/OpeningsTree.jsx
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, Fragment } from "react";
 
-function TreeNode({ side, node, path, selectedOpenings, expandedPaths, onToggle }) {
+function TreeNode({ node, path, selectedOpenings, expandedPaths, onToggle }) {
   const [kids, setKids] = useState([]);
   const [manualOpen, setManualOpen] = useState(false);
 
@@ -15,12 +15,11 @@ function TreeNode({ side, node, path, selectedOpenings, expandedPaths, onToggle 
   useEffect(() => {
     if (!isOpen) return;
     fetch(
-      `/api/openings?side=${side}&` +
-      path.map(p => `path[]=${p}`).join("&")
+      `/api/openings?` + path.map(p => `path[]=${p}`).join("&")
     )
       .then(r => r.json())
       .then(d => setKids(d.children));
-  }, [isOpen, path, side]);
+  }, [isOpen, path]);
 
   // Is this exact node selected?
   const isChecked = selectedOpenings.some(
@@ -56,7 +55,6 @@ function TreeNode({ side, node, path, selectedOpenings, expandedPaths, onToggle 
           {kids.map(child => (
             <TreeNode
               key={child.uci}
-              side={side}
               node={child}
               path={[...path, child.uci]}
               selectedOpenings={selectedOpenings}
@@ -70,7 +68,7 @@ function TreeNode({ side, node, path, selectedOpenings, expandedPaths, onToggle 
   );
 }
 
-export default function OpeningsTree({ side }) {
+export default function OpeningsTree() {
   const [roots, setRoots] = useState([]);
   const [selectedOpenings, setSelectedOpenings] = useState([]);
   const [expandedPaths, setExpandedPaths] = useState([]);
@@ -79,10 +77,10 @@ export default function OpeningsTree({ side }) {
 
   // Load first‑move roots
   useEffect(() => {
-    fetch(`/api/openings?side=${side}`)
+    fetch(`/api/openings`)
       .then(r => r.json())
       .then(d => setRoots(d.children));
-  }, [side]);
+  }, []);
 
   // Debounced search
   useEffect(() => {
@@ -114,7 +112,7 @@ export default function OpeningsTree({ side }) {
 
   return (
     <section style={{ marginBottom: "2rem" }}>
-      <h2>{side[0].toUpperCase() + side.slice(1)} openings</h2>
+      <h2>Select openings</h2>
 
       <input
         placeholder="Search…"
@@ -165,7 +163,6 @@ export default function OpeningsTree({ side }) {
         {roots.map(c => (
           <TreeNode
             key={c.uci}
-            side={side}
             node={c}
             path={[c.uci]}
             selectedOpenings={selectedOpenings}
@@ -177,7 +174,10 @@ export default function OpeningsTree({ side }) {
 
       {/* Hidden inputs so Flask sees opening names */}
       {selectedOpenings.map((o, i) => (
-        <input key={i} type="hidden" name={side} value={o.name} />
+        <Fragment key={i}>
+          <input type="hidden" name="white" value={o.name} />
+          <input type="hidden" name="black" value={o.name} />
+        </Fragment>
       ))}
     </section>
   );

--- a/chess_trainer/static/ui/src/index.jsx
+++ b/chess_trainer/static/ui/src/index.jsx
@@ -3,9 +3,4 @@ import { createRoot } from "react-dom/client";
 import OpeningsTree from "./OpeningsTree";
 
 const root = createRoot(document.getElementById("react-root"));
-root.render(
-  <>
-    <OpeningsTree side="white"  />
-    <OpeningsTree side="black"  />
-  </>
-);
+root.render(<OpeningsTree />);

--- a/chess_trainer/ui.py
+++ b/chess_trainer/ui.py
@@ -111,8 +111,13 @@ def index() -> str:
     message: Optional[str] = None
     if request.method == "POST":
         global EVENT_THREAD, STOP_EVENT
-        PROFILE.chosen_white = request.form.getlist("white")
-        PROFILE.chosen_black = request.form.getlist("black")
+        openings = request.form.getlist("openings")
+        if openings:
+            PROFILE.chosen_white = openings
+            PROFILE.chosen_black = openings
+        else:
+            PROFILE.chosen_white = request.form.getlist("white")
+            PROFILE.chosen_black = request.form.getlist("black")
         PROFILE.challenge = int(request.form.get("challenge", "0") or 0)
         username = request.form.get("username", "")
 
@@ -157,8 +162,13 @@ def profile() -> str:
     """Save settings and open the bot profile page in the user's browser."""
     global EVENT_THREAD, STOP_EVENT
 
-    PROFILE.chosen_white = request.form.getlist("white")
-    PROFILE.chosen_black = request.form.getlist("black")
+    openings = request.form.getlist("openings")
+    if openings:
+        PROFILE.chosen_white = openings
+        PROFILE.chosen_black = openings
+    else:
+        PROFILE.chosen_white = request.form.getlist("white")
+        PROFILE.chosen_black = request.form.getlist("black")
     PROFILE.challenge = int(request.form.get("challenge", "0") or 0)
 
     url = f"https://lichess.org/@/{OUR_NAME}"


### PR DESCRIPTION
## Summary
- consolidate UI opening tree into a single component
- duplicate chosen openings for both colours when posting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743ba69168832190cb8462121bc5d6