### PR TITLE
Invoke webpack programmatically during setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "chess_trainer",
   "version": "0.1.0",
   "scripts": {
-    "build": "webpack --mode production",
-    "watch": "webpack --watch"
+    "build": "node scripts/build-frontend.js",
+    "watch": "node scripts/build-frontend.js --watch"
   },
   "dependencies": {
     "react": "^18.x",

--- a/scripts/build-frontend.js
+++ b/scripts/build-frontend.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+const path = require('path');
+const webpack = require('webpack');
+
+const args = process.argv.slice(2);
+const isWatch = args.includes('--watch');
+
+const configPath = path.resolve(__dirname, '..', 'webpack.config.js');
+let config = require(configPath);
+if (typeof config === 'function') {
+  config = config({});
+}
+
+const compiler = webpack(config);
+
+const logStats = (stats) => {
+  const statsString = stats.toString({
+    colors: process.stdout.isTTY,
+    modules: false,
+    children: false,
+    chunks: false,
+    chunkModules: false,
+  });
+
+  if (statsString) {
+    console.log(statsString);
+  }
+};
+
+const handleResult = (err, stats, done) => {
+  if (err) {
+    console.error('Webpack encountered a fatal error:', err);
+    process.exitCode = 1;
+    if (done) done();
+    return;
+  }
+
+  logStats(stats);
+
+  if (stats.hasErrors()) {
+    const info = stats.toJson();
+    info.errors.forEach((error) => {
+      console.error(error.message || error);
+      if (error.stack) {
+        console.error(error.stack);
+      }
+    });
+    process.exitCode = 1;
+  }
+
+  if (stats.hasWarnings()) {
+    const info = stats.toJson();
+    info.warnings.forEach((warning) => {
+      console.warn(warning.message || warning);
+    });
+  }
+
+  if (done) done();
+};
+
+if (isWatch) {
+  console.log('Starting webpack in watch mode...');
+  compiler.watch({}, (err, stats) => handleResult(err, stats));
+} else {
+  compiler.run((err, stats) => {
+    handleResult(err, stats, () => {
+      compiler.close((closeErr) => {
+        if (closeErr) {
+          console.error('Failed to close webpack compiler cleanly:', closeErr);
+          process.exitCode = 1;
+        }
+        if (process.exitCode && process.exitCode !== 0) {
+          process.exit(process.exitCode);
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- restore the frontend assets pipeline so the prebuilt bundle is removed and the template loads the locally generated build
- add a node-based webpack helper and point the npm build/watch scripts at it to avoid relying on webpack-cli's bootstrap module
- run npm install/build again from setup.sh so setup.sh exercises the regenerated bundle

## Testing
- not run (npm dependencies cannot be installed in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d95f9b90ec8321b6e3c7805da63c8f